### PR TITLE
Small improvements to keyframe image-to-effect component

### DIFF
--- a/capstone/src/main/java/com/google/sps/data/KeyframeImage.java
+++ b/capstone/src/main/java/com/google/sps/data/KeyframeImage.java
@@ -12,19 +12,19 @@ public class KeyframeImage implements Comparable<KeyframeImage>{
   private String cloudBucketUrl;
   // The following integer variables is a time in number of seconds.
   private int timestamp;
-  private boolean isManuallyFlagged;
+  private boolean isManuallySelected;
   private HashMap<String, String> safeSearchEffect;
 
-  public KeyframeImage(String newUrl, int newTimestamp, boolean newIsManuallyFlagged) {
+  public KeyframeImage(String newUrl, int newTimestamp, boolean newIsManuallySelected) {
     cloudBucketUrl = newUrl;
     timestamp = newTimestamp;
-    isManuallyFlagged = newIsManuallyFlagged;
+    isManuallySelected = newIsManuallySelected;
   }
 
-  public KeyframeImage(String newUrl, int newTimestamp, boolean newIsManuallyFlagged, HashMap<String, String> newSafeSearchEffect) {
+  public KeyframeImage(String newUrl, int newTimestamp, boolean newIsManuallySelected, HashMap<String, String> newSafeSearchEffect) {
     cloudBucketUrl = newUrl;
     timestamp = newTimestamp;
-    isManuallyFlagged = newIsManuallyFlagged;
+    isManuallySelected = newIsManuallySelected;
     safeSearchEffect = newSafeSearchEffect;
   }
 
@@ -36,8 +36,8 @@ public class KeyframeImage implements Comparable<KeyframeImage>{
     return timestamp;
   }
 
-  public boolean getIsManuallyFlagged() {
-    return isManuallyFlagged;
+  public boolean getIsManuallySelected() {
+    return isManuallySelected;
   }
 
   public HashMap<String, String> getEffect() {

--- a/capstone/src/main/webapp/css/results.css
+++ b/capstone/src/main/webapp/css/results.css
@@ -238,6 +238,14 @@ hr {
   visibility: visible;
 }
 
+.wide-info {
+  width: 600px !important;
+}
+
+.show-to-left-info {
+  margin-left: -680px !important;
+}
+
 /* For user choice of displaying Flagged Keyframe Images or All Keyframe Images */
 #keyframe-display-allorflagged-buttons {
   margin: 0 auto;

--- a/capstone/src/main/webapp/js/image-effect-results.js
+++ b/capstone/src/main/webapp/js/image-effect-results.js
@@ -234,6 +234,8 @@ function createKeyframeImageTextInnerHTML(thisImage, timestampDisplayer) {
 
   var effect = thisImage.safeSearchEffect;
 
+  var isManuallySelected = thisImage.isManuallySelected;
+
   var effectsAsNumbers = setEffectsAsNumbers(effect);
 
   var htmlForAdultEffect = htmlForEffect(effect.adult, effectsAsNumbers, "Adult");
@@ -242,7 +244,11 @@ function createKeyframeImageTextInnerHTML(thisImage, timestampDisplayer) {
   var htmlForViolenceEffect = htmlForEffect(effect.violence, effectsAsNumbers, "Violence");
   var htmlForRacyEffect = htmlForEffect(effect.racy, effectsAsNumbers, "Racy");
 
-  timestampDisplayer.innerText = "Timestamp: " + timestamp;
+  if(isManuallySelected) {
+    timestampDisplayer.innerHTML = "<i class=\"fa fa-camera\" style=\"margin-right: 8px;\"></i>"
+  }
+
+  timestampDisplayer.innerHTML += "Timestamp: " + timestamp;
   var keyframeImageTextInnerHTML = '<h2 class="card-title">Effect of the frame </h2>' 
   + '<div class="card-text">'
   + '<p>Likeliness values are: Unknown, Very Unlikely, Unlikely, Possible, Likely, and Very Likely</p>'

--- a/capstone/src/main/webapp/results.html
+++ b/capstone/src/main/webapp/results.html
@@ -61,8 +61,15 @@
                 </h2>
                 <h2><div class="score-overall" id="visual-score-overall">?</div>
                     <div class="tooltip-info"><i class="fa fa-info-circle" aria-hidden="true"></i>
-                    <span class="tooltiptext-info">
-                        Description of overall score here
+                    <span class="tooltiptext-info wide-info">
+                        <p>The overall visual effect score represents how negative the video is. 0% = completely not negative. 100% = completely negative.
+                        </p>
+                        <p>
+                            The algorithm for the overall visual effect score penalizes all keyframe images flagged for Possible, Likely, or 
+                            Very Likely in any of the five categories of Adult, Medical, Spoofed, Violence, and Racy. It uses a scaled logarithmic function. 
+                            If there are any flagged sections found, there is a steep penalization in the algorithm for these flags. 
+                            This algorithm was designed with the goal of promoting safe content in video advertisements.
+                        </p>
                     </span>
                     </div>
                 </h2>
@@ -70,12 +77,12 @@
             <div class="column">
                 <h2>Audio Effect Score
                 </h2>
-                <h2><div class="score-overall" id="audio-score-overall">?</div>
-                    <div class="tooltip-info"><i class="fa fa-info-circle" aria-hidden="true"></i>
-                    <span class="tooltiptext-info">
+                <h2><div class="tooltip-info"><i class="fa fa-info-circle" aria-hidden="true"></i>
+                    <span class="tooltiptext-info wide-info show-to-left-info">
                         Description of overall score here
                     </span>
                     </div>
+                    <div class="score-overall" id="audio-score-overall">?</div>
                 </h2>
             </div>
         </div>

--- a/capstone/src/main/webapp/results.html
+++ b/capstone/src/main/webapp/results.html
@@ -62,8 +62,7 @@
                 <h2><div class="score-overall" id="visual-score-overall">?</div>
                     <div class="tooltip-info"><i class="fa fa-info-circle" aria-hidden="true"></i>
                     <span class="tooltiptext-info wide-info">
-                        <p>The overall visual effect score represents how negative the video is. 0% = completely not negative. 100% = completely negative.
-                        </p>
+                        <p>The overall visual effect score represents how negative the video is. 0% = completely not negative. 100% = completely negative.</p>
                         <p>
                             The algorithm for the overall visual effect score penalizes all keyframe images flagged for Possible, Likely, or 
                             Very Likely in any of the five categories of Adult, Medical, Spoofed, Violence, and Racy. It uses a scaled logarithmic function. 

--- a/capstone/src/main/webapp/results.html
+++ b/capstone/src/main/webapp/results.html
@@ -64,10 +64,9 @@
                     <span class="tooltiptext-info wide-info">
                         <p>The overall visual effect score represents how negative the video is. 0% = completely not negative. 100% = completely negative.</p>
                         <p>
-                            The algorithm for the overall visual effect score penalizes all keyframe images flagged for Possible, Likely, or 
-                            Very Likely in any of the five categories of Adult, Medical, Spoofed, Violence, and Racy. It uses a scaled logarithmic function. 
-                            If there are any flagged sections found, there is a steep penalization in the algorithm for these flags. 
-                            This algorithm was designed with the goal of promoting safe content in video advertisements.
+                            The algorithm for the overall visual effect score uses a scaled logarithmic function. 
+                            We penalize the video for every category per keyframe image that is flagged as Possible, Likely, or Very Likely in the categories of Adult, Medical, Spoofed, Violence, and Racy. 
+                            There is a steep penalization for these values in order to promote safer content in video advertisements.
                         </p>
                     </span>
                     </div>


### PR DESCRIPTION
### Additions
- Show a camera icon in the carousel of keyframe images on the Results page for keyframe images which are manually captured by the user on the Uploads page
![Screenshot 2020-08-04 at 4 43 57 PM](https://user-images.githubusercontent.com/51280054/89343134-d3209d80-d671-11ea-8b2a-cc662955082b.png)

- Add a hoverable description of how the overall visual score is generated
![Screenshot 2020-08-04 at 4 43 47 PM](https://user-images.githubusercontent.com/51280054/89343096-c603ae80-d671-11ea-96ee-c939824beb54.png)
